### PR TITLE
Increase max I/O trap range to 10

### DIFF
--- a/Src/HDPMI/I2FHDPMI.ASM
+++ b/Src/HDPMI/I2FHDPMI.ASM
@@ -145,7 +145,7 @@ SI_CPORT    equ 40h	; if IN/OUT: 1=port in bits 8-15
 SI_ADDR16   equ 40h	; if INS/OUTS: 1=don't use hiwords ESI/EDI/ECX
 SI_REPPRE   equ 80h
 
-NUMTRAP equ 8	; max trap ranges, currently static
+NUMTRAP equ 10	; max trap ranges, currently static
 
 TRAPPROCS struct
 if ?32BIT


### PR DESCRIPTION
This PR increases max I/O trap range to 10.

I need this for my VSBHDA fork, in order to alter the value returned from VGA port 0x3DA/0x3BA to fix games running potentially too fast on modern AMD GPUs.