### PR TITLE
Added the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 1996-2026 Japheth (Andreas Grech)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,37 @@
-MIT License
+HX Source-Restricted License
 
-Copyright (c) 1996-2026 Japheth (Andreas Grech)
+Copyright (c) 1996-2026 Japheth
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Use and modification of the source code, and redistribution and use in binary
+form, with or without modification, are permitted provided that the following
+conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. The source code, whether modified or unmodified, may not be redistributed,
+   published, or otherwise made available to third parties, except when
+   submitted directly to the official project as a proposed contribution, such
+   as through a patch or pull request. For the purposes of this license, the
+   "official project" is the project repository or other contribution channel
+   maintained or expressly designated by the copyright holder.
+2. By submitting source code through an official contribution channel, the
+   contributor grants the copyright holder a perpetual, worldwide,
+   non-exclusive, royalty-free, and irrevocable license to use, reproduce,
+   modify, sublicense, and redistribute the contribution in source and binary
+   form as part of the official project under this License.
+3. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions, and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+4. Binary forms produced from modified source code must be clearly identified
+   as modified and must not be represented as official versions of the
+   software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Hello,

I'm also very interested in using this amazing project, and the licensing is really the main thing holding me back. There are four open issues about it:

- https://github.com/Baron-von-Riedesel/HX/issues/1
- https://github.com/Baron-von-Riedesel/HX/issues/8
- https://github.com/Baron-von-Riedesel/HX/issues/66
- https://github.com/Baron-von-Riedesel/HX/issues/67

In issue #1 you wrote that you don't like the GPL. I don't like it either, though for a different reason: it stops my own code from being used. That's why I went with MIT in my projects. It asks for attribution, which seems fair to me, but otherwise lets people use the code however they need, including in closed source projects.

MIT is a short and simple license. In short, anyone can use, copy, modify and distribute the software, in commercial or closed source projects, as long as they keep your copyright and the license text along with it. In exchange the software comes with no warranty and you take on no liability. There is no copyleft, so nobody is forced to open their own code.

I want to be upfront about one thing. In issue #66 you said commercial use is fine as long as HX isn't modified. MIT does allow modification, so adopting it would be a real change from what you said there. Personally I think allowing modifications is a good thing, it lets people fix bugs and adapt HX to their needs, but it's your project and your call. If you'd rather keep the no-modifications rule, then MIT isn't the right fit and we should look at something else.

I took the liberty of putting this PR together to make the decision easier if you do want to go with MIT. The LICENSE file is at the root with your copyright (1996-2026 Japheth). If it looks good you can just merge it, and it would close all four issues above at once. Whatever you decide, thanks for keeping HX alive after all these years.